### PR TITLE
downgraded brrp for automated building and releasing

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,9 +11,9 @@ base {
 }
 
 repositories {
+	maven { url "https://raw.githubusercontent.com/SolidBlock-cn/mvn-repo/main" }
 	maven { url "https://maven.terraformersmc.com/releases/" }
 	maven { url "https://maven.shedaniel.me" }
-	flatDir { dir "${rootDir}/deps" }
 }
 
 fabricApi {

--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,6 @@ archives_base_name=rRandomizerPlusPlus
 
 # Dependencies
 fabric_version=0.96.11+1.20.4
-brrp_version=1.0.3-1.20.4
+# there is a stable version but not from the maven repo yet
+brrp_version=1.0.3-beta.3-1.20.4
 rei_version=14.0.688


### PR DESCRIPTION
This downgrade is only for the automated building, a stable version exists and is the one that would be used outside of development environments.